### PR TITLE
Fix <1536px width not using gradio breakpoints

### DIFF
--- a/config/page.py
+++ b/config/page.py
@@ -1,0 +1,4 @@
+from config.paths import BasePaths
+
+with open(BasePaths.container_stylesheet, 'r') as file:
+    head_style = f"<style>\n" + file.read() + "\n</style>"

--- a/config/paths.py
+++ b/config/paths.py
@@ -1,5 +1,4 @@
 import sys
-import os
 
 from pathlib import Path
 from platformdirs import user_config_path, user_pictures_dir
@@ -8,7 +7,7 @@ from datetime import datetime
 ## Application paths
 
 APP_TITLE = "diffuser dials"
-APP_NAME = APP_TITLE.lower()
+APP_NAME = APP_TITLE.lower().replace(" ", "-")
 
 class BasePaths:
     # works for both pyinstaller packaged and not pysintaller packaged
@@ -18,7 +17,8 @@ class BasePaths:
     css: Path = resources / "css"
     js: Path = resources / "js"
     images: Path = resources / "images"
-    theme: Path = css / "theme.css"
+    stylesheet: Path = css / "styles.css"
+    container_stylesheet: Path = css / "container_styles.css"
     workarounds: Path = js / "workarounds.js"
     config_file: Path = Path(user_config_path(APP_NAME)) / "config.json"
     output_dir: Path = Path(user_pictures_dir())

--- a/css/container_styles.css
+++ b/css/container_styles.css
@@ -1,0 +1,11 @@
+/* the css= kwarg in gradio.Blocks only applies to elementw inside 
+   the gradio app container, not the container itself so we have
+   to insert this rule separately using the head= kwarg.
+*/
+
+@media (min-width: 1536px)
+{
+    .gradio-container {
+        min-width: var(--size-full) !important;
+    }
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -21,33 +21,6 @@ footer {
     z-index: 1000;
 }
 
-/* Overall sizing */
-
-/* display in full width for desktop devices, but see below */
-/* @media (min-width: 1536px)
-{
-    .gradio-container {
-        max-width: var(--size-full) !important;
-    }
-} */
-
-/* media rules in custom css are don't appear to be applied in
-   gradio versions > 4.7, so we have to define a class which
-   we will manually need add and remove using javascript.
-   Remove this once this fixed in gradio.
-*/
-/* .gradio-container-size-full {
-    max-width: var(--size-full) !important;
-} */
-
-.gradio-container {
-    max-width: var(--size-full) !important;
-}
-
-.gradio-container .contain {
-    padding: 0 var(--size-4) !important;
-}
-
 /* buttons with glyphs */
 
 .output_icon_button {

--- a/diffuser-dials.py
+++ b/diffuser-dials.py
@@ -3,16 +3,16 @@ import PIL.Image as Image
 
 from config.paths import BasePaths, APP_NAME
 from config.args import args
+from config.page import head_style
 from gallery_ui import outputgallery, tab_select
-
 
 def ui() -> gr.Blocks:
     with gr.Blocks(        
-        css=BasePaths.theme,
-        #js=BasePaths.workarounds
+        css=BasePaths.stylesheet,
+        head=head_style,
         analytics_enabled=False,
         title=APP_NAME,
-        delete_cache=(7200, 7200)
+        delete_cache=(7200, 7200),
     ) as diffuser_dials:
         logo = Image.open(BasePaths.images / "logo-medium.png")
         gr.Image(
@@ -35,4 +35,6 @@ if __name__ == "__main__":
         server_port=args.port,
         favicon_path=BasePaths.images / "logo-medium.png",
         allowed_paths=[BasePaths.output_dir],
+        show_api=False,
+        inbrowser=True,
     )


### PR DESCRIPTION
### Motivation

I want the width to of the UI to fill the whole browser width at 1920px. Gradio implements @media breakpoints that limit the maximum UI width to 1536px. The previous JavaScript workaround for this as implemented in SHARK broke with Gradio 4.21 as there seems to be an issue applying any additional Javascript at all at Block level.

As a temporary expedient I simply forced full width at all breakpoint sizes.

This removes that and implements a different method for styling the main gradio container >1536px to full width, so other breakpoints should now revert to the default gradio behaviour.

### Changes

- Remove the override forcing app to be have width 100% at all media sizes.
- Add a 'head=' kwarg to the main gradio Blocks call to fully apply @media styles for the overall gradio app container, as gradio does not register when put them in the file referenced by the 'css=' kwarg
- Add a 'container_styles.css' to container for app container @media styling that sizes to 100% only at 1536px and above.
- Load container_styles.css so it can reference in the Blocks 'head='
- Some renaming and cleanup for styling and paths.