### PR TITLE
Small improvements to UI positioning and sizing

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -21,6 +21,21 @@ footer {
     z-index: 1000;
 }
 
+/* centered logo for when there are no images */
+#top_logo.logo_centered {
+    height: 100%;
+    width: 100%;
+    background-color: var(--background-fill-secondary);
+}
+
+#top_logo.logo_centered img {
+    object-fit: scale-down;
+    position: absolute;
+    width: 80%;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
 /* buttons with glyphs */
 .output_icon_button {
     max-width: 30px;
@@ -35,13 +50,15 @@ footer {
     min-height: calc(100vmin - var(--size-20) - var(--size-6)) !important;
 }
 
-.sd-right-panel {
-    height: calc(100vmin - var(--size-24)) !important;
+.right-panel {
+    min-height: calc(100vmin - var(--size-20) - var(--size-6)) !important;
     overflow-y: scroll;
 }
 
-.sd-right-panel .fill {
-    flex: 1;
+.right-panel .end-fill {
+    flex-grow: 1;
+    align-content: flex-end;
+    align-items: last baseline;
 }
 
 .output_parameters_dataframe table.table {

--- a/gallery_ui.py
+++ b/gallery_ui.py
@@ -71,7 +71,7 @@ with gr.Blocks() as outputgallery:
         gallery_files = gr.State(value=[])
         subdirectory_paths = gr.State(value=output_subdirs())
 
-        with gr.Column(scale=6):
+        with gr.Column(scale=6, min_width=640):
             logo = gr.Image(
                 label="No Images",
                 value=app_logo,
@@ -87,11 +87,11 @@ with gr.Blocks() as outputgallery:
                 value=gallery_files.value,
                 visible=False,
                 show_label=True,
-                columns=4,
+                columns=2,
                 object_fit="contain",
             )
 
-        with gr.Column(scale=4):
+        with gr.Column(scale=4, elem_classes=["right-panel"], min_width=240):
             with gr.Group():
                 with gr.Row(elem_id="output_subdir_container"):
                     with gr.Column(
@@ -130,7 +130,7 @@ with gr.Blocks() as outputgallery:
                         )
 
             image_columns = gr.Slider(
-                label="Columns shown", value=4, minimum=1, maximum=16, step=1
+                label="Columns shown", value=2, minimum=1, maximum=10, step=1
             )
             outputgallery_filename = gr.Textbox(
                 label="Filename",
@@ -142,17 +142,18 @@ with gr.Blocks() as outputgallery:
                 label="Parameter Information", open=True
             ) as parameters_accordian:
                 image_parameters = gr.DataFrame(
+                    elem_classes=["output_parameters_dataframe"],
+                    height=600,
                     headers=["Parameter", "Value"],
                     datatype=["str", "str"],
                     col_count=(2, "fixed"),
                     row_count=(1, "fixed"),
                     wrap=True,
-                    elem_classes="output_parameters_dataframe",
                     value=[["Status", "No image selected"]],
                     interactive=True,
                     type="array",
                 )
-            with gr.Row():
+            with gr.Row(elem_classes=["end-fill"]):
                 with gr.Column(scale=3):
                     runner = gr.Dropdown(
                         show_label=False,


### PR DESCRIPTION
### Changes

- Make generate button row pad to the bottom of the column if there is space.
- Set max height of parameter info to be a bit bigger.
- make logo image, not so overwhelming in size, when no other images to show.
- Start gallery at 2 column and set max 10 columns, as anything beyond that didn't actually get applied.