### PR TITLE
Update gradio to 4.36.1

### DIFF
--- a/diffuser-dials.py
+++ b/diffuser-dials.py
@@ -28,11 +28,6 @@ def ui() -> gr.Blocks:
 
 
 if __name__ == "__main__":
-    # allow direct serving of images from the outputdir if self-hosting
-    # TODO: Make this a separate non-default command line option
-    if args.host in ["localhost", "127.0.0.1", "::1"]:
-        gr.set_static_paths([paths.output_dir])
-
     ui().launch(
         share=False,
         server_name=args.host,
@@ -42,5 +37,6 @@ if __name__ == "__main__":
         show_api=False,
         inbrowser=True,
     )
+
 else:
     demo = ui()

--- a/gallery_ui.py
+++ b/gallery_ui.py
@@ -184,7 +184,6 @@ with gr.Blocks() as outputgallery:
                             elem_classes=["parameter_label"],
                             max_lines=1,
                         )
-                        print(f"param: {param}")
                         if param[2] is not None:
                             parameter_controls.append(
                                 gr.Dropdown(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,17 @@
+black==24.3.0
+  click==8.1.7
+  mypy-extensions==1.0.0
+  packaging==24.0
+  pathspec==0.12.1
+  platformdirs==4.2.0
 colorama==0.4.6
-gradio==4.22.0
+flake8-bugbear==24.2.6
+  attrs==23.2.0
+  flake8==7.0.0
+    mccabe==0.7.0
+    pycodestyle==2.11.1
+    pyflakes==3.2.0
+gradio==4.36.1
   aiofiles==23.2.1
   altair==5.2.0
     Jinja2==3.1.3
@@ -23,19 +35,49 @@ gradio==4.22.0
       pytz==2024.1
       tzdata==2024.1
     toolz==0.12.1
-  fastapi==0.110.0
+  fastapi==0.111.0
+    email_validator==2.1.1
+      dnspython==2.6.1
+      idna==3.6
+    fastapi-cli==0.0.4
+      typer==0.12.3
+        click==8.1.7
+        rich==13.7.1
+          markdown-it-py==3.0.0
+            mdurl==0.1.2
+          Pygments==2.17.2
+        shellingham==1.5.4
+        typing_extensions==4.10.0
+    httpx==0.27.0
+      anyio==4.3.0
+        idna==3.6
+        sniffio==1.3.1
+      certifi==2024.2.2
+      httpcore==1.0.4
+        certifi==2024.2.2
+        h11==0.14.0
+      idna==3.6
+      sniffio==1.3.1
+    Jinja2==3.1.3
+      MarkupSafe==2.1.5
+    orjson==3.9.15
     pydantic==2.6.4
       annotated-types==0.6.0
       pydantic_core==2.16.3
         typing_extensions==4.10.0
       typing_extensions==4.10.0
-    starlette==0.36.3
+    python-multipart==0.0.9
+    starlette==0.37.2
       anyio==4.3.0
         idna==3.6
         sniffio==1.3.1
     typing_extensions==4.10.0
+    ujson==5.10.0
+    uvicorn==0.28.0
+      click==8.1.7
+      h11==0.14.0
   ffmpy==0.3.2
-  gradio_client==0.13.0
+  gradio_client==1.0.1
     fsspec==2024.2.0
     httpx==0.27.0
       anyio==4.3.0
@@ -121,17 +163,25 @@ gradio==4.22.0
   ruff==0.3.2
   semantic-version==2.10.0
   tomlkit==0.12.0
-  typer==0.9.0
+  typer==0.12.3
     click==8.1.7
+    rich==13.7.1
+      markdown-it-py==3.0.0
+        mdurl==0.1.2
+      Pygments==2.17.2
+    shellingham==1.5.4
     typing_extensions==4.10.0
   typing_extensions==4.10.0
+  urllib3==2.2.1
   uvicorn==0.28.0
     click==8.1.7
     h11==0.14.0
+httptools==0.6.1
 install==1.3.5
-platformdirs==4.2.0
-rich==13.7.1
-  markdown-it-py==3.0.0
-    mdurl==0.1.2
-  Pygments==2.17.2
-shellingham==1.5.4
+isort==5.13.2
+python-dotenv==1.0.1
+uvloop==0.19.0
+watchfiles==0.22.0
+  anyio==4.3.0
+    idna==3.6
+    sniffio==1.3.1


### PR DESCRIPTION

### Changes

- Update gradio to 4.36.1
- Remove gr.set_static_paths call as this appears to be broken

### Possible Problems/Concerns

- removing gr.set_static_paths means gradio will create a bunch of temporary files which we're relying on it to cleanup. This has been problematic in the past.