### PR TITLE
Update gradio/certifi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,25 @@
+altair==5.2.0
+  Jinja2==3.1.4
+    MarkupSafe==2.1.5
+  jsonschema==4.21.1
+    attrs==23.2.0
+    jsonschema-specifications==2023.12.1
+      referencing==0.33.0
+        attrs==23.2.0
+        rpds-py==0.18.0
+    referencing==0.33.0
+      attrs==23.2.0
+      rpds-py==0.18.0
+    rpds-py==0.18.0
+  numpy==1.26.4
+  packaging==24.0
+  pandas==2.2.1
+    numpy==1.26.4
+    python-dateutil==2.9.0.post0
+      six==1.16.0
+    pytz==2024.1
+    tzdata==2024.1
+  toolz==0.12.1
 black==24.3.0
   click==8.1.7
   mypy-extensions==1.0.0
@@ -11,30 +33,11 @@ flake8-bugbear==24.2.6
     mccabe==0.7.0
     pycodestyle==2.11.1
     pyflakes==3.2.0
-gradio==4.37.2
+gradio==4.39.0
   aiofiles==23.2.1
-  altair==5.2.0
-    Jinja2==3.1.4
-      MarkupSafe==2.1.5
-    jsonschema==4.21.1
-      attrs==23.2.0
-      jsonschema-specifications==2023.12.1
-        referencing==0.33.0
-          attrs==23.2.0
-          rpds-py==0.18.0
-      referencing==0.33.0
-        attrs==23.2.0
-        rpds-py==0.18.0
-      rpds-py==0.18.0
-    numpy==1.26.4
-    packaging==24.0
-    pandas==2.2.1
-      numpy==1.26.4
-      python-dateutil==2.9.0.post0
-        six==1.16.0
-      pytz==2024.1
-      tzdata==2024.1
-    toolz==0.12.1
+  anyio==4.3.0
+    idna==3.7
+    sniffio==1.3.1
   fastapi==0.111.0
     email_validator==2.1.1
       dnspython==2.6.1
@@ -52,9 +55,9 @@ gradio==4.37.2
       anyio==4.3.0
         idna==3.7
         sniffio==1.3.1
-      certifi==2024.2.2
+      certifi==2024.7.4
       httpcore==1.0.4
-        certifi==2024.2.2
+        certifi==2024.7.4
         h11==0.14.0
       idna==3.7
       sniffio==1.3.1
@@ -77,15 +80,15 @@ gradio==4.37.2
       click==8.1.7
       h11==0.14.0
   ffmpy==0.3.2
-  gradio_client==1.0.2
+  gradio_client==1.1.1
     fsspec==2024.2.0
     httpx==0.27.0
       anyio==4.3.0
         idna==3.7
         sniffio==1.3.1
-      certifi==2024.2.2
+      certifi==2024.7.4
       httpcore==1.0.4
-        certifi==2024.2.2
+        certifi==2024.7.4
         h11==0.14.0
       idna==3.7
       sniffio==1.3.1
@@ -95,7 +98,7 @@ gradio==4.37.2
       packaging==24.0
       PyYAML==6.0.1
       requests==2.32.3
-        certifi==2024.2.2
+        certifi==2024.7.4
         charset-normalizer==3.3.2
         idna==3.7
         urllib3==2.2.2
@@ -108,9 +111,9 @@ gradio==4.37.2
     anyio==4.3.0
       idna==3.7
       sniffio==1.3.1
-    certifi==2024.2.2
+    certifi==2024.7.4
     httpcore==1.0.4
-      certifi==2024.2.2
+      certifi==2024.7.4
       h11==0.14.0
     idna==3.7
     sniffio==1.3.1
@@ -120,7 +123,7 @@ gradio==4.37.2
     packaging==24.0
     PyYAML==6.0.1
     requests==2.32.3
-      certifi==2024.2.2
+      certifi==2024.7.4
       charset-normalizer==3.3.2
       idna==3.7
       urllib3==2.2.2


### PR DESCRIPTION
### Changes

- Bump gradio version to 4.39.0
- Bump certifi version to 2024.7.4 (dependabot)