### PR TITLE
Add dropdown for sampler selection

### DIFF
--- a/config/engines/stable-diffusion-cpp-cli.json
+++ b/config/engines/stable-diffusion-cpp-cli.json
@@ -147,7 +147,33 @@
         {
             "class": "display",
             "source": "Sampler",
-            "default": "euler_a karras"
+            "default": "euler_a karras",
+            "one_of": [
+                "euler",
+                "euler karras",
+                "euler ays",
+                "euler_a",
+                "euler_a karras",
+                "euler_a ays",
+                "heun",
+                "heun karras",
+                "heun ays",
+                "dpm2",
+                "dpm2 karras",
+                "dpm2 ays",
+                "dpm++2s_a",
+                "dpm++2s_a karras",
+                "dpm++2s_a ays",
+                "dpm++2m",
+                "dpm++2m karras",
+                "dpm++2m ays",
+                "dpm++2mv2",
+                "dpm++2mv2 karras",
+                "dpm++2mv2 ays",
+                "lcm",
+                "lcm karras",
+                "lcm ays"
+            ]
         },
         {
             "class": "display",


### PR DESCRIPTION
### Motivation

I can't remember the valid sampler names for the stable-diffusion.cpp backend. So the backend definition should list them, and I should get a dropdown to select from them.

### Changes

- Replace textbox for sampler selection with dropdown